### PR TITLE
no longer fails if dumb user exists

### DIFF
--- a/vpn_install_arch.sh
+++ b/vpn_install_arch.sh
@@ -58,7 +58,7 @@ install_dependencies() {
     echo -e "\e[7m3/7\e[27m - \e[33mInstalling dependencies...\e[0m"
 
 
-	useradd --system --create-home aur-user-qzwsxedc &&
+	id -u aur-user-qzwsxedc &>/dev/null || useradd --system --create-home aur-user-qzwsxedc &&
 	echo 'aur-user-qzwsxedc ALL=NOPASSWD: /usr/bin/pacman' > /etc/sudoers.d/aur-user-qzwsxedc &&
 
 	pacman -S lib32-libx11 lib32-pam openssl libnss_nis xterm --noconfirm >$STDOUT 2>&1 &&


### PR DESCRIPTION
script no longer fails if user already exists. useful if the script
failed or the user already exists on the machine (highly unlikely).