### PR TITLE
no longer fails if directory already exists

### DIFF
--- a/vpn_install_arch.sh
+++ b/vpn_install_arch.sh
@@ -69,7 +69,7 @@ install_dependencies() {
 }
 
 make_temp_dir() {
-    mkdir vpnInstaller
+    mkdir -p vpnInstaller
     if [ $? != 0 ]; then
         echo -e "\e[31mFailed at creating temporary folder! (A folder called vpnInstaller already exists)\e[0m"
         return 1


### PR DESCRIPTION
script no longer fails if directory already exists.helpful if the script fails during the VPN installation stage. 